### PR TITLE
Added flag codes, country codes and language codes support for Europe

### DIFF
--- a/lib/src/flag_code.dart
+++ b/lib/src/flag_code.dart
@@ -75,6 +75,7 @@ class FlagCode {
     ['ERI', 'ER']: 'er',
     ['ESP', 'ES']: 'es',
     ['ETH', 'ET']: 'et',
+    ['EUR', 'EU']: 'eu',
     ['FIN', 'FI']: 'fi',
     ['FJI', 'FJ']: 'fj',
     ['FLK', 'FK']: 'fk',


### PR DESCRIPTION

## I Added flag codes, country codes and language codes support for Europe

<!--- The  `CountryFlag.fromCountryCode('EU')` code shows a question mark icon, so i added the eur currency support to the `_flagCodesCountries` map-->

## New Feature

- [x ] ✨ New feature (non-breaking change which adds functionality)
- [ x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
