### PR TITLE
Added 'cn' as base flag for Chinese

### DIFF
--- a/lib/src/flag_code.dart
+++ b/lib/src/flag_code.dart
@@ -563,6 +563,7 @@ class FlagCode {
     'xh': 'za',
     'yi': 'il',
     'za': 'za',
+    'zh': 'cn',
     'zh-cn': 'cn',
     'zh-tw': 'tw',
     'zu': 'za',


### PR DESCRIPTION
## Description

The language code 'zh' was not added. It is on the [list linked in the README](http://www.lingoes.net/en/translator/langcode.htm#:~:text=Xhosa%20(South%20Africa)-,zh,-Chinese). Also, the prefix 'zh' was used for the dialects, so there should be a base associated.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
