### PR TITLE
chore: fixed changelog for better readability on pub.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,23 @@
-## 1.0.0
+## 4.0.1
 
-- First release
+- fix: add the two missing stripes to the Malaysian flag
 
-## 1.1.0
+## 4.0.0
 
-- Upgrade flutter_svg dependency
+- feat: add emoji flags style
 
-## 1.1.1
+## 3.3.0
 
-- Fix Bolivian flag
+- feat: add support for currency codes
 
-## 2.0.0
+## 3.2.0
 
-- Add the ability to create flags from a language code
+- feat: change Syrian flag
 
-## 2.1.0
+## 3.1.0
 
-- perf: switch to jovial_svg for faster rendering
-- feat: upgrade to support Dart ^3.0.0
-- refactor: remove unused intl library
-- refactor: upgrade collection, very_good_analysis
-
-## 2.1.1
-
-- fix: add missing language codes cs, tr and sk
-
-## 2.2.0
-
-- feat: add Swedish language code
+- fix: added all missing translations from language-code to country code
+- feat: add support for three-letter country codes
 
 ## 3.0.0
 
@@ -38,23 +28,33 @@
 - fix: add GB-SCT, GB-WLS, GB-ENG, GB-NIR subdivisions
 - fix: Czech Republic language code
 
-## 3.1.0
+## 2.2.0
 
-- fix: added all missing translations from language-code to country code
-- feat: add support for three-letter country codes
+- feat: add Swedish language code
 
-## 3.2.0
+## 2.1.1
 
-- feat: change Syrian flag
+- fix: add missing language codes cs, tr and sk
 
-## 3.3.0
+## 2.1.0
 
-- feat: add support for currency codes
+- perf: switch to jovial_svg for faster rendering
+- feat: upgrade to support Dart ^3.0.0
+- refactor: remove unused intl library
+- refactor: upgrade collection, very_good_analysis
 
-## 4.0.0
+## 2.0.0
 
-- feat: add emoji flags style
+- Add the ability to create flags from a language code
 
-## 4.0.1
+## 1.1.1
 
-- fix: add the two missing stripes to the Malaysian flag
+- Fix Bolivian flag
+
+## 1.1.0
+
+- Upgrade flutter_svg dependency
+
+## 1.0.0
+
+- First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - feat: add emoji flags style
 
+BREAKING CHANGES:
+
+- feat: created `FlagTheme` class to encapsulate theming
+
 ## 3.3.0
 
 - feat: add support for currency codes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,15 @@ BREAKING CHANGES:
 
 ## 3.0.0
 
-- refactor: remove borderRadius property, use shape property now - ${\text{\color{orange}Breaking Change}}$
 - feat: add two new shapes: Circle and RoundedRectangle
 - fix: add missing kosovo country code
 - fix: add missing Portuguese language code
 - fix: add GB-SCT, GB-WLS, GB-ENG, GB-NIR subdivisions
 - fix: Czech Republic language code
+
+BREAKING CHANGES:
+
+- refactor: remove borderRadius property, use shape property now
 
 ## 2.2.0
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Recently I've upgraded from 3.3.0 to 4.0.1 in my project and encountered a _minor_, but still, breaking change. Going thought the changelog I've noticed that it wasn't ordered like I've come to expect from Flutter packages (newest first) and said breaking change wasn't disclosed.

Short story apart, this PR 
- fixes the ordering of the `CHANGELOG.md` to facilitate reading it on pub.dev; 
- added the breaking change to the 4.0.0 version entry;
- fixed a minor visual bug that happened on pub.dev, since it wasn't rendering the `${\text{\color{orange}Breaking Change}}$` markdown properly.


Markdown bug:
<img width="798" height="197" alt="image" src="https://github.com/user-attachments/assets/d2aaf7ec-5e9e-462a-9488-cd64a636930b" />


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [X] 🗑️ Chore
